### PR TITLE
Improvements 2

### DIFF
--- a/concerts.php
+++ b/concerts.php
@@ -6,24 +6,7 @@
 // ini_set("html_errors", 1);
 // error_reporting(E_ALL);
 
-function executeRESTCall(string $method, string $url, string $body)
-{
-    $curl = curl_init();
-    curl_setopt($curl, CURLOPT_URL, $url);
-    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
-
-    $header = [];
-    $header[] = 'Content-type: application/json';
-    $header[] = 'Authorization: averylongauthkey';
-
-    curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-
-    return curl_exec($curl);
-}
-
-$baseUrl = 'https://api.speedadmin.dk/v1/%s';
+require_once(__DIR__.'/lib/executeRESTCall.php');
 
 //  PublishTypeIds
 // 	1 læreportal
@@ -34,7 +17,7 @@ $baseUrl = 'https://api.speedadmin.dk/v1/%s';
 // Fetch concerts using the API
 // BookingTypeId 9 link to concerts
 // DateFrom exclude all concerts before today
-$concertsJSONString = executeRESTCall('POST', sprintf($baseUrl, 'bookings'), '{
+$concertsJSONString = executeRESTCall('POST', '/bookings', '{
     "BookingTypeIds": [9],
     "PublishTypeIds": [4],
     "DateFrom": "'.date('Y-m-d').'"

--- a/concerts.php
+++ b/concerts.php
@@ -67,7 +67,7 @@ $concerts = json_decode($concertsJSONString);
                 <th>Date</th>
             </tr>
         </thead>
-        <?php if (null !== $concerts->Results) {
+        <?php if (null !== $concerts && null !== $concerts->Results) {
             foreach ($concerts->Results as $concert) { ?>
                 <tr>
                     <td><?php echo $concert->Title; ?></td>

--- a/concerts_advanced.php
+++ b/concerts_advanced.php
@@ -6,24 +6,7 @@
 // ini_set("html_errors", 1);
 // error_reporting(E_ALL);
 
-function executeRESTCall(string $method, string $url, ?string $body = null)
-{
-    $curl = curl_init();
-    curl_setopt($curl, CURLOPT_URL, $url);
-    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
-
-    $header = [];
-    $header[] = 'Content-type: application/json';
-    $header[] = 'Authorization: averylongauthkey'; // Add you own authorization key
-
-    curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-
-    return curl_exec($curl);
-}
-
-$baseUrl = 'https://api.speedadmin.dk/v1/%s';
+require_once(__DIR__.'/lib/executeRESTCall.php');
 
 //  PublishTypeIds
 // 	1 læreportal
@@ -34,7 +17,7 @@ $baseUrl = 'https://api.speedadmin.dk/v1/%s';
 // Fetch concerts using the API
 // BookingTypeId 9 link to concerts
 // DateFrom exclude all concerts before today
-$concertsJSONString = executeRESTCall('POST', sprintf($baseUrl, 'bookings'), '{
+$concertsJSONString = executeRESTCall('POST', '/bookings', '{
     "BookingTypeIds": [9],
     "PublishTypeIds": [1],
     "DateFrom": "'.date('Y-m-d').'"
@@ -89,7 +72,7 @@ $formatter = new IntlDateFormatter($locale, IntlDateFormatter::LONG, IntlDateFor
                 <th>Description</td>
             </tr>
         </thead>
-        <?php if (null !== $concerts->Results) {
+        <?php if (null !== $concerts && null !== $concerts->Results) {
             foreach ($concerts->Results as $concert) { ?>
                 <tr>
                     <td><?php 

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,6 @@
+<?php 
+
+const CONFIG = [
+    'API_KEY' => 'averylongapikey', // Add you own authorization key
+    'BASE_URL' => 'https://api.speedadmin.dk/v1',
+];

--- a/course_with_combo.php
+++ b/course_with_combo.php
@@ -3,22 +3,9 @@
 
 
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+    require_once(__DIR__.'/lib/executeRESTCall.php');
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: xUxzYpVhcB4u5YmY60B43HwOHVkKF3Q2GYnyWk4gV8';
-
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-    $baseUrl = 'https://api.speedadmin.dk/v1/';
-
-    $coursesJSONString = executeRESTCall('GET', $baseUrl . 'courses' );
+    $coursesJSONString = executeRESTCall('GET', '/courses' );
 
     // Convert JSON string to Object
     $courses = json_decode($coursesJSONString);

--- a/courses.php
+++ b/courses.php
@@ -2,22 +2,9 @@
 <html>
 
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+    require_once(__DIR__.'/lib/executeRESTCall.php');
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: 1ThIsIsRanDomLettERsCkQKkjiOi2pZwA1shPrandomStUfF';
-
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-    $baseUrl = 'https://api.speedadmin.dk/v1/';
-
-    $coursesJSONString = executeRESTCall('GET', $baseUrl . 'courses');
+    $coursesJSONString = executeRESTCall('GET', '/courses');
 
     // Convert JSON string to Object
     $courses = json_decode($coursesJSONString);

--- a/get-blob.php
+++ b/get-blob.php
@@ -8,4 +8,10 @@
 
 require_once('lib/executeRESTCall.php');
 
+// Return 404 error if no ID
+if (null === $_GET['id']) {
+    http_response_code(404);
+    die();
+}
+
 echo executeRESTCall('GET', sprintf('/blobs/%s', $_GET['id']));

--- a/get-blob.php
+++ b/get-blob.php
@@ -6,20 +6,6 @@
 // ini_set("html_errors", 1);
 // error_reporting(E_ALL);
 
-function executeRESTCall($method, $url) {
-    $curl = curl_init();
-    curl_setopt($curl, CURLOPT_URL, $url);
-    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+require_once('lib/executeRESTCall.php');
 
-    $header = array();
-    $header[] = 'Content-type: application/json';
-    $header[] = 'Authorization: averylongauthkey'; // Add you own authorization key
-
-    curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-    return curl_exec($curl);
-}
-
-$baseUrl = 'https://api.speedadmin.dk/v1/%s';
-
-echo executeRESTCall('GET', sprintf($baseUrl, 'blobs/'.$_GET['id']));
+echo executeRESTCall('GET', sprintf('/blobs/%s', $_GET['id']));

--- a/lib/executeRESTCall.php
+++ b/lib/executeRESTCall.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once(__DIR__.'/../config/config.php');
+
+function executeRESTCall(string $method, string $path, ?string $body = null)
+{
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_URL, CONFIG['BASE_URL'] . $path);
+    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
+
+    $header = [];
+    $header[] = 'Content-type: application/json';
+    $header[] = 'Authorization: ' . CONFIG['API_KEY'];
+
+    curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+    return curl_exec($curl);
+}

--- a/news.php
+++ b/news.php
@@ -2,22 +2,10 @@
 <html>
 <h2>NEWS</h2>
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: xf33dgd5Y1kZbpHfRxZUxqlqwJaZJWCkQKkjiOi2pZwA1shPkIBgjkodqBngeQu2';
+    require_once(__DIR__.'/lib/executeRESTCall.php');
 
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-    $baseUrl = 'https://api.speedadmin.dk/v1/';
-
-    $newsJSONString = executeRESTCall('GET', $baseUrl . 'news');
+    $newsJSONString = executeRESTCall('GET', '/news');
 
     // Convert JSON string to Object
     $news = json_decode($newsJSONString);

--- a/store-all-images.php
+++ b/store-all-images.php
@@ -1,22 +1,10 @@
 
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: 8VWZ22JpVW1jbU5DcGd5QTNGLzNleUFPRFZ2aG5DYTFzYWR0ejFPR';
-
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-        $baseUrl = 'https://api.speedadmin.dk/v1/';
+  require_once(__DIR__.'/lib/executeRESTCall.php');
 
           // executeRESTCall('GET', 'https://api.speedadmin.dk/v1/teachers/496');
-            $teachersJSONString = executeRESTCall('GET', $baseUrl . 'teachers');
+            $teachersJSONString = executeRESTCall('GET', '/teachers');
 
             // Convert JSON string to Object and returns an array
             $teachers = json_decode($teachersJSONString);
@@ -25,7 +13,7 @@
             foreach($teachers as $key => $value) {
 
              // gets the raw image data
-             $blobJSONString = executeRESTCall('GET', $baseUrl . 'blobs/' . $value->Blob->BlobId);
+             $blobJSONString = executeRESTCall('GET', '/blobs/' . $value->Blob->BlobId);
 
              // creates a filename with the teacher ID
              $unikfilename = "images/Teacher_". strval($value->TeacherId) . ".jpg";

--- a/teachers-image-blobs.php
+++ b/teachers-image-blobs.php
@@ -1,21 +1,16 @@
-
 <?php
 
-  require_once(__DIR__.'/lib/executeRESTCall.php');
+require_once(__DIR__.'/lib/executeRESTCall.php');
 
-          // executeRESTCall('GET', 'https://api.speedadmin.dk/v1/teachers/496');
-            $teachersJSONString = executeRESTCall('GET', '/teachers');
+// executeRESTCall('GET', 'https://api.speedadmin.dk/v1/teachers/496');
+$teachersJSONString = executeRESTCall('GET', '/teachers');
 
-            // Convert JSON string to Object and returns an array
-            $teachers = json_decode($teachersJSONString);
+// Convert JSON string to Object and returns an array
+$teachers = json_decode($teachersJSONString);
 
-            // Use a foreach loop to grab the each individual teachers blob
-            foreach($teachers as $key => $value) {
-              // gets the raw image data
-              $blobJSONString = executeRESTCall('GET', '/blobs/' . $value->Blob->BlobId);
-
-              // saviour line! This turns the image data into an image
-              echo "<img src='data:image/jpeg;base64," . base64_encode( $blobJSONString )."' width='80px' width='120px'><br>";
-        }
-
-        ?>
+// Use a foreach loop to grab the each individual teachers
+foreach($teachers as $teacher) {
+  if (null !== $teacher->Blob->BlobId) {
+    echo sprintf("<img src='./get-blob.php?id=%s' height='120px' loading='lazy'><br>", $teacher->Blob->BlobId);
+  }
+}

--- a/teachers-image-blobs.php
+++ b/teachers-image-blobs.php
@@ -1,22 +1,10 @@
 
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: averylongauthkey'; // Add you own authorization key
-
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-        $baseUrl = 'https://api.speedadmin.dk/v1/';
+  require_once(__DIR__.'/lib/executeRESTCall.php');
 
           // executeRESTCall('GET', 'https://api.speedadmin.dk/v1/teachers/496');
-            $teachersJSONString = executeRESTCall('GET', $baseUrl . 'teachers');
+            $teachersJSONString = executeRESTCall('GET', '/teachers');
 
             // Convert JSON string to Object and returns an array
             $teachers = json_decode($teachersJSONString);
@@ -24,7 +12,7 @@
             // Use a foreach loop to grab the each individual teachers blob
             foreach($teachers as $key => $value) {
               // gets the raw image data
-              $blobJSONString = executeRESTCall('GET', $baseUrl . 'blobs/' . $value->Blob->BlobId);
+              $blobJSONString = executeRESTCall('GET', '/blobs/' . $value->Blob->BlobId);
 
               // saviour line! This turns the image data into an image
               echo "<img src='data:image/jpeg;base64," . base64_encode( $blobJSONString )."' width='80px' width='120px'><br>";

--- a/teachers.php
+++ b/teachers.php
@@ -1,22 +1,10 @@
 <table width="100%">
 <?php
-    function executeRESTCall($method, $url) {
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 
-        $header = array();
-        $header[] = 'Content-type: application/json';
-        $header[] = 'Authorization: xf33dgd5Y1kZbpHfRxZUxqlqwJaZJWCkQKkjiOi2pZwA1shPkIBgjkodqBngeQu2';
+  require_once(__DIR__.'/lib/executeRESTCall.php');
 
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        return curl_exec($curl);
-    }
-    $baseUrl = 'https://api.speedadmin.dk/v1/';
-
-         $teachersJSONString = executeRESTCall('GET', $baseUrl . 'teachers');
-            // $getMads = executeRESTCall('GET', 'https://api.speedadmin.dk/v1/teachers/496');
+         $teachersJSONString = executeRESTCall('GET', '/teachers');
+            // $getMads = executeRESTCall('GET', '/teachers/496');
 
 
             // Convert JSON string to Object


### PR DESCRIPTION
- Split `executeRESTCall()` into its own file ;
- Move config vars into their own file ;
- Return 404 error if no **id** is provided to `get-blob.php` ;
- Use `get-blob.php` instead of base64 encoding in `teachers-image-blobs.php` ;
- Check _null_ concerts in addition of _null_ concerts results.